### PR TITLE
chore(#6): provide commitlint pre-commit

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 utils/
 test/
+commitlint.config.js
 *.md

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,15 @@
 repos:
-- repo: https://github.com/catosplace/pre-commit-docker-image
-# - repo: ../pre-commit-docker-image
-  rev: 0.0.4
-  hooks:
-  - id: hadolint
-  - id: shellcheck
+
+  - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+    rev: v2.2.0
+    hooks:
+      - id: commitlint
+        stages: [commit-msg]
+        additional_dependencies: ['@commitlint/config-conventional']
+
+  - repo: https://github.com/catosplace/pre-commit-docker-image
+  # - repo: ../pre-commit-docker-image
+    rev: 0.0.4
+    hooks:
+      - id: hadolint
+      - id: shellcheck

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,9 @@
+const Configuration = {
+  extends: ['@commitlint/config-conventional'],
+
+  rules: {
+    'scope-empty': [ 2, "never" ],
+  },
+};
+
+module.exports = Configuration;


### PR DESCRIPTION
Initial implementation of [commitlint](https://commitlint.js.org/#/). Used [pre-commit hook](https://github.com/alessandrojcm/commitlint-pre-commit-hook). Updated the rules to enforce the inclusion of a scope.